### PR TITLE
Add Sendable declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,17 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.10
 
 import PackageDescription
 
 let package = Package(
     name: "Pushover",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .macCatalyst(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+        .visionOS(.v1)
+    ],
     products: [
         .library(
             name: "Pushover",

--- a/Sources/Pushover/API.swift
+++ b/Sources/Pushover/API.swift
@@ -14,7 +14,7 @@ import FoundationNetworking
 typealias JSON = [String: Any]
 
 enum API {
-    static func send(_ request: URLRequest, completion: @escaping (Result<([String: String], JSON), Error>) -> Void) {
+    static func send(_ request: URLRequest, completion: @escaping @Sendable (Result<([String: String], JSON), Error>) -> Void) {
         URLSession.shared.dataTask(with: request) { data, response, error in
             if let _ = error { completion(.failure(.network)); return }
 

--- a/Sources/Pushover/Response.swift
+++ b/Sources/Pushover/Response.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A response from the Pushover API
-public struct Response {
+public struct Response: Sendable {
     let status: Int
     let request: String
     let message: String?
@@ -17,11 +17,11 @@ public struct Response {
     let errors: [String]?
 
     /// Your app's limit
-    var limit: UInt? = nil
+    let limit: UInt?
     /// Your app's remaining pushs for this time period.
-    var remaining: UInt? = nil
+    let remaining: UInt?
     /// Timestamp when your app's remaining count will be reset.
-    var reset: Date? = nil
+    let reset: Date?
 
     init?(fromJSON json: JSON, andHeaders headers: [String: String]) {
         guard let status = json["status"] as? Int,
@@ -34,8 +34,8 @@ public struct Response {
         self.message = json["message"] as? String
         self.errors = json["errors"] as? [String]
 
-        if let limit = headers["X-Limit-App-Limit"] { self.limit = UInt(limit) ?? 0 }
-        if let remaining = headers["X-Limit-App-Remaining"] { self.remaining = UInt(remaining) ?? 0 }
-        if let reset = headers["X-Limit-App-Reset"] { self.reset = Date(timeIntervalSince1970: Double(reset) ?? 0) }
+        limit = if let limit = headers["X-Limit-App-Limit"] { UInt(limit) ?? 0 } else { nil }
+        remaining = if let remaining = headers["X-Limit-App-Remaining"] { UInt(remaining) ?? 0 } else { nil }
+        reset = if let reset = headers["X-Limit-App-Reset"] { Date(timeIntervalSince1970: Double(reset) ?? 0) } else { nil }
     }
 }


### PR DESCRIPTION
This is needed for Swift 6.0 compatibility. The compiler complains otherwise, for example if the `Pushover` instance is made available in a shared context. Since the properties are constant anyways, no changes are needed to the structs.

For ease-of-use reasons, I compiled everything with Swit 6.0 but reverted the declaration in `Package.swift` back to 5.10.
I assume this will allow people running the Swift 5 compiler to upgrade without any problems.

**Note**: In the process, I removed the function `sendSynchronously` since it was passing mutable state across concurrency domains. IMO this can be removed since I don't see the use-case for it, and waiting for an async task is pretty simple to implement using current versions of `swift-argument-parser`, for example. Happy to discuss this, though.

As another point of discussion, one could think about removing the old completion-based APIs and only provide async/await APIs. I think this mostly changes the implementation in `API.swift` to use [`URLSession.data(for:delegate:)`](https://developer.apple.com/documentation/foundation/urlsession/3767352-data), and will change other portions of the code which use that function. This would complete potentially breaking changes that could be bundled in a release.

Happy holidays 🎄 🎆 