### PR TITLE
Migrate to async URLSession API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,25 @@ Simple little wrapper for the [Pushover](https://pushover.net) API. Use it to se
 
 ```swift
 // Create a pushover object with your API token.
-let pushover = Pushover(token: "YOUR_TOKEN")
+let pushover = Pushover(token: "<#API_TOKEN#>")
 
 // Send a simple message directly.
-pushover.send("Lorem ipsum dolor sit amet.", to: "USER_OR_GROUP_KEY")
+try await pushover.send("Lorem ipsum dolor sit amet.", to: "<#USER_OR_GROUP_KEY#>")
 
 // Use `Notification`s to use more of Pushover's features.
-let notification = Notification(message: "Lorem ipsum.", to: "USER")
+let notification = Notification(message: "Lorem ipsum.", to: "<#USER#>")
     .devices(["iPhone"])
     .url("https://example.com")
     .urlTitle("Dolor sit amet")
     .priority(.high)
     .sound(.intermission)
 
-pushover.send(notification)
-
-// Use the callback to define actions based on error or success cases.
-pushover.send(notification) { result in
-    // A .success result case means that there were no network, server or decoding errors.
+do {
+    let response = try await pushover.send(notification)
     // The request might still have failed due to a wrong API token, exceeded limits or
     // other problems. Be sure to check the response value for more information.
+} catch {
+    // An error case means that there was a network, server or decoding error.
 }
 ```
 
@@ -47,7 +46,8 @@ Package.swift:
 
 ## Contributors
 
-Kilian Koeltzsch, [@kiliankoe](https://github.com/kiliankoe)
+- Kilian Koeltzsch, [@kiliankoe](https://github.com/kiliankoe)
+- Sören Gade, [@sgade](https://github.com/sgade)
 
 ## License
 

--- a/Sources/Pushover/API.swift
+++ b/Sources/Pushover/API.swift
@@ -14,21 +14,26 @@ import FoundationNetworking
 typealias JSON = [String: Any]
 
 enum API {
-    static func send(_ request: URLRequest, completion: @escaping @Sendable (Result<([String: String], JSON), Error>) -> Void) {
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            if let _ = error { completion(.failure(.network)); return }
+    static func send(_ request: URLRequest) async throws(Error) -> ([String: String], JSON) {
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
 
-            guard let statusCode = (response as? HTTPURLResponse)?.statusCode else { completion(.failure(.network)); return }
-            guard let headers = (response as? HTTPURLResponse)?.allHeaderFields as? [String: String] else { completion(.failure(.network)); return }
+            guard let httpResponse = response as? HTTPURLResponse,
+                  let headers = httpResponse.allHeaderFields as? [String: String]
+            else {
+                throw Error.network
+            }
 
-            if case 500...599 = statusCode { completion(.failure(.server)); return }
+            if case 500...599 = httpResponse.statusCode {
+                throw Error.server
+            }
 
-            guard let data = data else { completion(.failure(.network)); return }
-
-            guard let deserialized = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) else { completion(.failure(.decoding)); return }
-            guard let json = deserialized as? JSON else { completion(.failure(.decoding)); return }
-
-            completion(.success((headers, json)))
-        }.resume()
+            guard let deserialized = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? JSON else {
+                throw Error.decoding
+            }
+            return (headers, deserialized)
+        } catch {
+            throw Error.network
+        }
     }
 }

--- a/Sources/Pushover/API.swift
+++ b/Sources/Pushover/API.swift
@@ -14,26 +14,26 @@ import FoundationNetworking
 typealias JSON = [String: Any]
 
 enum API {
-    static func send(_ request: URLRequest) async throws(Error) -> ([String: String], JSON) {
+    static func send(_ request: URLRequest) async throws(PushoverError) -> ([String: String], JSON) {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   let headers = httpResponse.allHeaderFields as? [String: String]
             else {
-                throw Error.network
+                throw PushoverError.network
             }
 
             if case 500...599 = httpResponse.statusCode {
-                throw Error.server
+                throw PushoverError.server
             }
 
             guard let deserialized = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? JSON else {
-                throw Error.decoding
+                throw PushoverError.decoding
             }
             return (headers, deserialized)
         } catch {
-            throw Error.network
+            throw PushoverError.network
         }
     }
 }

--- a/Sources/Pushover/Error.swift
+++ b/Sources/Pushover/Error.swift
@@ -9,12 +9,13 @@
 import Foundation
 
 /// Possible error case that can be encountered.
-///
-/// - server: Something unexpected went wrong on the server side.
-/// - network: Sending of the request failed.
-/// - decoding: The received data could not be decoded.
 public enum Error: Swift.Error {
+    /// Something unexpected went wrong on the server side.
     case server
+
+    /// Sending of the request failed.
     case network
+
+    /// The received data could not be decoded.
     case decoding
 }

--- a/Sources/Pushover/Priority.swift
+++ b/Sources/Pushover/Priority.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 Kilian Koeltzsch. All rights reserved.
 //
 
-import Foundation
-
 /// Custom priority values.
 ///
 /// See here for more details: https://pushover.net/api#priority

--- a/Sources/Pushover/Pushover.swift
+++ b/Sources/Pushover/Pushover.swift
@@ -27,7 +27,7 @@ public struct Pushover: Sendable {
     ///
     /// - Throws: An ``Error`` case.
     /// - Returns: The ``Response`` value.
-    public func send(_ message: String, to user: String) async throws(Error) -> Response {
+    public func send(_ message: String, to user: String) async throws(PushoverError) -> Response {
         try await send(Notification(message: message, to: user))
     }
 
@@ -36,14 +36,14 @@ public struct Pushover: Sendable {
     /// - Parameter notification: notification to be sent
     /// - Throws: An ``Error`` case.
     /// - Returns: The ``Response`` value.
-    public func send(_ notification: Notification) async throws(Error) -> Response {
+    public func send(_ notification: Notification) async throws(PushoverError) -> Response {
         var request = URLRequest(url: Endpoint.messages)
         request.httpMethod = "POST"
         request.add(notification: notification, withToken: self.token)
 
         let (headers, json) = try await API.send(request)
         guard let response = Response(fromJSON: json, andHeaders: headers) else {
-            throw Error.decoding
+            throw PushoverError.decoding
         }
         return response
     }

--- a/Sources/Pushover/Pushover.swift
+++ b/Sources/Pushover/Pushover.swift
@@ -27,6 +27,7 @@ public struct Pushover: Sendable {
     ///
     /// - Throws: An ``Error`` case.
     /// - Returns: The ``Response`` value.
+    @discardableResult
     public func send(_ message: String, to user: String) async throws(PushoverError) -> Response {
         try await send(Notification(message: message, to: user))
     }
@@ -36,6 +37,7 @@ public struct Pushover: Sendable {
     /// - Parameter notification: notification to be sent
     /// - Throws: An ``Error`` case.
     /// - Returns: The ``Response`` value.
+    @discardableResult
     public func send(_ notification: Notification) async throws(PushoverError) -> Response {
         var request = URLRequest(url: Endpoint.messages)
         request.httpMethod = "POST"

--- a/Sources/Pushover/Pushover.swift
+++ b/Sources/Pushover/Pushover.swift
@@ -24,60 +24,27 @@ public struct Pushover: Sendable {
     /// - Parameters:
     ///   - message: message to be sent
     ///   - user: recipient
-    ///   - completion: handler provided with a result value
-    public func send(_ message: String, to user: String, completion: @escaping @Sendable (Result<Response, Error>) -> Void) {
-        send(Notification(message: message, to: user), completion: completion)
-    }
-
-    /// Send a message directly to a user bypassing further customization options.
     ///
-    /// - Parameters:
-    ///   - message: message to be sent
-    ///   - user: recipient
-    ///
-    /// - Returns: The response value
-    @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, tvOS 13.0, watchOS 13.0, *)
-    @discardableResult
-    public func send(_ message: String, to user: String) async throws -> Response {
-        return try await withCheckedThrowingContinuation { continuation in
-            send(message, to: user) {
-                continuation.resume(with: $0)
-            }
-        }
-    }
-
-    /// Send a `Notification` to Pushover.
-    ///
-    /// - Parameters:
-    ///   - notification: notification to be sent
-    ///   - completion: handler provided with a result value
-    public func send(_ notification: Notification, completion: @escaping @Sendable (Result<Response, Error>) -> Void) {
-        var request = URLRequest(url: Endpoint.messages)
-        request.httpMethod = "POST"
-        request.add(notification: notification, withToken: self.token)
-
-        API.send(request) { result in
-            switch result {
-            case let .failure(error):
-                completion(.failure(error))
-            case let .success((headers, json)):
-                guard let response = Response(fromJSON: json, andHeaders: headers) else { completion(.failure(.decoding)); return }
-                completion(.success(response))
-            }
-        }
+    /// - Throws: An ``Error`` case.
+    /// - Returns: The ``Response`` value.
+    public func send(_ message: String, to user: String) async throws(Error) -> Response {
+        try await send(Notification(message: message, to: user))
     }
 
     /// Send a `Notification` to Pushover.
     ///
     /// - Parameter notification: notification to be sent
-    /// - Returns: The response value
-    @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, tvOS 13.0, watchOS 13.0, *)
-    @discardableResult
-    public func send(_ notification: Notification) async throws -> Response {
-        return try await withCheckedThrowingContinuation { continuation in
-            send(notification) {
-                continuation.resume(with: $0)
-            }
+    /// - Throws: An ``Error`` case.
+    /// - Returns: The ``Response`` value.
+    public func send(_ notification: Notification) async throws(Error) -> Response {
+        var request = URLRequest(url: Endpoint.messages)
+        request.httpMethod = "POST"
+        request.add(notification: notification, withToken: self.token)
+
+        let (headers, json) = try await API.send(request)
+        guard let response = Response(fromJSON: json, andHeaders: headers) else {
+            throw Error.decoding
         }
+        return response
     }
 }

--- a/Sources/Pushover/PushoverError.swift
+++ b/Sources/Pushover/PushoverError.swift
@@ -1,15 +1,13 @@
 //
-//  Error.swift
+//  PushoverError.swift
 //  Pushover
 //
 //  Created by Kilian Költzsch on 01/02/2017.
 //  Copyright © 2017 Kilian Koeltzsch. All rights reserved.
 //
 
-import Foundation
-
 /// Possible error case that can be encountered.
-public enum Error: Swift.Error {
+public enum PushoverError: Error {
     /// Something unexpected went wrong on the server side.
     case server
 

--- a/Sources/Pushover/Sound.swift
+++ b/Sources/Pushover/Sound.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 Kilian Koeltzsch. All rights reserved.
 //
 
-import Foundation
-
 /// Custom sounds.
 ///
 /// See here for more details: https://pushover.net/api#sounds


### PR DESCRIPTION
As discussed in #3, I removed the completion-block-based APIs and directly use [`URLSession.data(for:)`](https://developer.apple.com/documentation/foundation/urlsession/3767352-data).

The existing public `async` APIs stay the same.
However, for users of the now-removed APIs it will be a migration, so a new major version might be appropriate to communicate the breaking change.
At the same time, I leveraged Swift 6's typed throws so that the information of the concrete `Error` type is kept.